### PR TITLE
しりとりの可用性向上機能を実装

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,11 @@ Deno.serve(async (_req) => {
     // JSONの中からnextWordを取得
     const nextWord = requestJson["nextWord"];
 
-    if (words.slice(-1)[0].slice(-1) === nextWord.slice(0, 1)) {
+    if (
+      words.slice(-1)[0].slice(-1) === nextWord.slice(0, 1) ||
+      (words.slice(-1)[0].slice(-1) === "ー" &&
+        words.slice(-1)[0].slice(-2, -1) === nextWord.slice(0, 1))
+    ) {
       words.push(nextWord);
     } else {
       return new Response(

--- a/server.js
+++ b/server.js
@@ -3,6 +3,22 @@ import { serveDir, serveFile } from "jsr:@std/http/file-server";
 
 let words = ["しりとり"];
 
+// 拗音対応map
+const normalizeKana = (char) => {
+  const map = {
+    "ゃ": "や",
+    "ゅ": "ゆ",
+    "ょ": "よ",
+    "ぁ": "あ",
+    "ぃ": "い",
+    "ぅ": "う",
+    "ぇ": "え",
+    "ぉ": "お",
+    "っ": "つ",
+  };
+  return map[char] || char; // マップにない場合はそのまま返す
+};
+
 Deno.serve(async (_req) => {
   const pathname = new URL(_req.url).pathname;
 
@@ -33,9 +49,10 @@ Deno.serve(async (_req) => {
     const nextWord = requestJson["nextWord"];
 
     if (
-      words.slice(-1)[0].slice(-1) === nextWord.slice(0, 1) ||
+      normalizeKana(words.slice(-1)[0].slice(-1)) === nextWord.slice(0, 1) ||
       (words.slice(-1)[0].slice(-1) === "ー" &&
-        words.slice(-1)[0].slice(-2, -1) === nextWord.slice(0, 1))
+        normalizeKana(words.slice(-1)[0].slice(-2, -1)) ===
+          nextWord.slice(0, 1))
     ) {
       words.push(nextWord);
     } else {

--- a/src/js/single_game.js
+++ b/src/js/single_game.js
@@ -1,3 +1,15 @@
+const setPreviousWord = (previousWord) => {
+  const mainPart = previousWord.slice(0, -1);
+  const lastChar = previousWord.slice(-1);
+  const paragraph = document.getElementById("previousWord");
+  // const span = document.getElementById("lastPreviousChar");
+  paragraph.textContent = `前の単語: ${mainPart}`;
+  const span = document.createElement("span");
+  span.className = "highlight";
+  span.textContent = lastChar;
+  paragraph.appendChild(span);
+};
+
 const changeGameOver = (isGameOver) => {
   document.getElementById("shiritoriContainer").style.display = isGameOver
     ? "none"
@@ -27,8 +39,7 @@ const judgeResults = (words) => {
     paragraph.innerText =
       `"${previousWord}"が入力されました。\n同じワードが再送されたのでゲームを終了します。`;
   } else {
-    const paragraph = document.getElementById("previousWord");
-    paragraph.textContent = `前の単語: ${previousWord}`;
+    setPreviousWord(previousWord);
   }
   return;
 };
@@ -116,8 +127,7 @@ document.querySelectorAll(".resetButton").forEach((resetButton) => {
     );
     const words = await response.json();
 
-    const paragraph = document.getElementById("previousWord");
-    paragraph.textContent = `前の単語: ${words.slice(-1)[0]}`;
+    setPreviousWord(words.slice(-1)[0]);
     nextWordInput.value = "";
 
     changeGameOver(false);

--- a/src/js/single_game.js
+++ b/src/js/single_game.js
@@ -5,6 +5,7 @@ const changeGameOver = (isGameOver) => {
   document.getElementById("gameoverContainer").style.display = isGameOver
     ? "flex"
     : "none";
+  return;
 };
 
 const judgeResults = (words) => {
@@ -29,6 +30,7 @@ const judgeResults = (words) => {
     const paragraph = document.getElementById("previousWord");
     paragraph.textContent = `前の単語: ${previousWord}`;
   }
+  return;
 };
 
 globalThis.onload = async () => {
@@ -36,15 +38,50 @@ globalThis.onload = async () => {
   const response = await fetch("/shiritori", { method: "GET" });
   const words = await response.json();
   judgeResults(words);
+  return;
 };
+
+const inputTextValidation = (isValid) => {
+  const input = document.getElementById("nextWordInput");
+  const inputError = document.getElementById("inputError");
+  if (!isValid) {
+    input.classList.add("error");
+    inputError.classList.remove("isHidden");
+  } else {
+    input.classList.remove("error");
+    inputError.classList.add("isHidden");
+  }
+  return;
+};
+
+// 入力validation
+document.getElementById("nextWordInput").addEventListener("input", (event) => {
+  const input = event.target;
+  const sendButton = document.getElementById("nextWordSendButton");
+
+  const isValid = /^[\u3040-\u309F]+$/.test(input.value);
+  if (!isValid) {
+    sendButton.classList.add("disabled");
+  } else {
+    sendButton.classList.remove("disabled");
+  }
+  return;
+});
+
 // 送信ボタンの押下時に実行
 document.getElementById("nextWordSendButton").onclick = async () => {
   // inputタグを取得
   const nextWordInput = document.getElementById("nextWordInput");
   // inputの中身を取得
   const nextWordInputText = nextWordInput.value;
+
+  const isValid = /^[\u3040-\u309F]+$/.test(nextWordInputText);
+  inputTextValidation(isValid);
+  if (!isValid) {
+    return;
+  }
+
   // POST /shiritoriを実行
-  // 次の単語をresponseに格納
   const response = await fetch(
     "/shiritori",
     {
@@ -65,6 +102,7 @@ document.getElementById("nextWordSendButton").onclick = async () => {
 
   // inputタグの中身を消去する
   nextWordInput.value = "";
+  return;
 };
 
 document.querySelectorAll(".resetButton").forEach((resetButton) => {
@@ -84,4 +122,5 @@ document.querySelectorAll(".resetButton").forEach((resetButton) => {
 
     changeGameOver(false);
   };
+  return;
 });

--- a/src/js/single_game.js
+++ b/src/js/single_game.js
@@ -2,12 +2,21 @@ const setPreviousWord = (previousWord) => {
   const mainPart = previousWord.slice(0, -1);
   const lastChar = previousWord.slice(-1);
   const paragraph = document.getElementById("previousWord");
-  // const span = document.getElementById("lastPreviousChar");
-  paragraph.textContent = `前の単語: ${mainPart}`;
   const span = document.createElement("span");
   span.className = "highlight";
-  span.textContent = lastChar;
-  paragraph.appendChild(span);
+  if (lastChar === "ー") {
+    paragraph.textContent = `前の単語: ${mainPart.slice(0, -1)}`;
+    span.textContent = previousWord.slice(-2, -1);
+    const lastSpan = document.createElement("span");
+    lastSpan.textContent = lastChar;
+    paragraph.appendChild(span);
+    paragraph.appendChild(lastSpan);
+  } else {
+    paragraph.textContent = `前の単語: ${mainPart}`;
+    span.textContent = lastChar;
+    paragraph.appendChild(span);
+  }
+  return;
 };
 
 const changeGameOver = (isGameOver) => {
@@ -70,7 +79,7 @@ document.getElementById("nextWordInput").addEventListener("input", (event) => {
   const input = event.target;
   const sendButton = document.getElementById("nextWordSendButton");
 
-  const isValid = /^[\u3040-\u309F]+$/.test(input.value);
+  const isValid = /^[ぁ-んー]+$/u.test(input.value);
   if (!isValid) {
     sendButton.classList.add("disabled");
   } else {
@@ -86,7 +95,7 @@ document.getElementById("nextWordSendButton").onclick = async () => {
   // inputの中身を取得
   const nextWordInputText = nextWordInput.value;
 
-  const isValid = /^[\u3040-\u309F]+$/.test(nextWordInputText);
+  const isValid = /^[ぁ-んー]+$/u.test(nextWordInputText);
   inputTextValidation(isValid);
   if (!isValid) {
     return;

--- a/src/pages/single_play.html
+++ b/src/pages/single_play.html
@@ -16,8 +16,9 @@
         <h1>しりとり</h1>
         <p id="previousWord"></p>
         <input class="textInput" id="nextWordInput" type="text" />
+        <p id="inputError">ひらがなのみで入力してください</p>
         <div class="flex">
-          <button class="button" id="nextWordSendButton">送信</button>
+          <button class="button" id="nextWordSendButton" desabled>送信</button>
           <button class="button resetButton">リセット</button>
         </div>
       </div>

--- a/src/pages/single_play.html
+++ b/src/pages/single_play.html
@@ -18,7 +18,7 @@
         <input class="textInput" id="nextWordInput" type="text" />
         <p id="inputError">ひらがなのみで入力してください</p>
         <div class="flex">
-          <button class="button" id="nextWordSendButton" desabled>送信</button>
+          <button class="button" id="nextWordSendButton">送信</button>
           <button class="button resetButton">リセット</button>
         </div>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -114,3 +114,8 @@ body {
 .isHidden {
   visibility: hidden;
 }
+
+.highlight {
+  color: red;
+  font-weight: bold;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,7 +52,8 @@ body {
 
 .button {
   padding: 5px;
-  margin: 5px;
+  margin-left: 5px;
+  margin-right: 5px;
   width: 150px;
   font-size: 100%;
   border: none;
@@ -65,14 +66,30 @@ body {
   align-items: center;
 }
 
+.button.disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .button:active {
   transform: translateY(2px);
 }
 
+.button.disabled:active {
+  transform: none;
+}
+
 .textInput {
   padding: 10px;
-  margin: 10px;
+  margin: 10px, 10px, 0px;
   width: 300px;
+}
+
+.textInput.error {
+  border: 2px solid red;
+  background-color: #ffe6e6;
 }
 
 .backLink {
@@ -86,4 +103,14 @@ body {
   text-align: left;
   text-decoration: none;
   user-select: none;
+}
+
+#inputError {
+  color: #b9314f;
+  font-size: 15px;
+  left: auto;
+}
+
+.isHidden {
+  visibility: hidden;
 }


### PR DESCRIPTION
## 変更点
- しりとりの入力値にvalidationを付与し、ひらがな以外を含む文字が入力されているときは送信ボタンをクリックできないように変更
- 送信ボタンがクリックできない状態のときにクリックすると、エラーメッセージが出るように変更
- 次のワードの先頭の文字に当たる文字をハイライトする機能を実装
- 伸ばし棒("ー")や拗音に対応

## 動作画面
![image](https://github.com/user-attachments/assets/467d4425-a211-4a0b-a0a5-dafa2635331d)
